### PR TITLE
Add GetRelativeUrl method

### DIFF
--- a/Sources/EasyExtensions.WebDav/IWebDavCloudClient.cs
+++ b/Sources/EasyExtensions.WebDav/IWebDavCloudClient.cs
@@ -59,5 +59,13 @@ namespace EasyExtensions.WebDav
         /// <param name="filePath"> The file path. </param>
         /// <returns> The file bytes. </returns>
         Task<byte[]> GetFileBytesAsync(string filePath);
+
+        /// <summary>
+        /// Substracts the base address from the given URL.
+        /// </summary>
+        /// <param name="fullUrl"> The full URL. </param>
+        /// <returns> The relative URL. </returns>
+        /// <remarks> The full URL must start with the base address. </remarks>
+        string GetRelativeUrl(string fullUrl);
     }
 }

--- a/Sources/EasyExtensions.WebDav/IWebDavCloudClient.cs
+++ b/Sources/EasyExtensions.WebDav/IWebDavCloudClient.cs
@@ -17,6 +17,12 @@ namespace EasyExtensions.WebDav
         WebDavClient GetWebDavClient();
 
         /// <summary>
+        /// Gets the base address.
+        /// </summary>
+        /// <returns> The base address. </returns>
+        string GetBaseAddress();
+
+        /// <summary>
         /// Creates a folder on the WebDAV server if it does not exist.
         /// </summary>
         /// <param name="folder"> The folder name. </param>
@@ -59,13 +65,5 @@ namespace EasyExtensions.WebDav
         /// <param name="filePath"> The file path. </param>
         /// <returns> The file bytes. </returns>
         Task<byte[]> GetFileBytesAsync(string filePath);
-
-        /// <summary>
-        /// Substracts the base address from the given URL.
-        /// </summary>
-        /// <param name="fullUrl"> The full URL. </param>
-        /// <returns> The relative URL. </returns>
-        /// <remarks> The full URL must start with the base address. </remarks>
-        string GetRelativeUrl(string fullUrl);
     }
 }

--- a/Sources/EasyExtensions.WebDav/WebDavCloudClient.cs
+++ b/Sources/EasyExtensions.WebDav/WebDavCloudClient.cs
@@ -201,7 +201,7 @@ namespace EasyExtensions.WebDav
         /// Substracts the base address from the full URL.
         /// </summary>
         /// <returns> The path without the base address if it starts with the base address. If not, the full URL is returned. </returns>
-        private string GetRelativeUrl(string fullUrl)
+        public string GetRelativeUrl(string fullUrl)
         {
             if (string.IsNullOrEmpty(fullUrl))
             {

--- a/Sources/EasyExtensions.WebDav/WebDavCloudClient.cs
+++ b/Sources/EasyExtensions.WebDav/WebDavCloudClient.cs
@@ -201,7 +201,7 @@ namespace EasyExtensions.WebDav
         /// Substracts the base address from the full URL.
         /// </summary>
         /// <returns> The path without the base address if it starts with the base address. If not, the full URL is returned. </returns>
-        private string GetBaseAddress(string fullUrl)
+        private string SubstractBaseAddress(string fullUrl)
         {
             if (string.IsNullOrEmpty(fullUrl))
             {

--- a/Sources/EasyExtensions.WebDav/WebDavCloudClient.cs
+++ b/Sources/EasyExtensions.WebDav/WebDavCloudClient.cs
@@ -198,20 +198,12 @@ namespace EasyExtensions.WebDav
         }
 
         /// <summary>
-        /// Substracts the base address from the full URL.
+        /// Gets the base address.
         /// </summary>
-        /// <returns> The path without the base address if it starts with the base address. If not, the full URL is returned. </returns>
-        public string GetRelativeUrl(string fullUrl)
+        /// <returns> The base address. </returns>
+        public string GetBaseAddress()
         {
-            if (string.IsNullOrEmpty(fullUrl))
-            {
-                return _baseAddress;
-            }
-            if (fullUrl.StartsWith(_baseAddress))
-            {
-                return fullUrl[_baseAddress.Length..];
-            }
-            return fullUrl;
+            return _baseAddress;
         }
 
         /// <summary>

--- a/Sources/EasyExtensions.WebDav/WebDavCloudClient.cs
+++ b/Sources/EasyExtensions.WebDav/WebDavCloudClient.cs
@@ -198,6 +198,23 @@ namespace EasyExtensions.WebDav
         }
 
         /// <summary>
+        /// Substracts the base address from the full URL.
+        /// </summary>
+        /// <returns> The path without the base address if it starts with the base address. If not, the full URL is returned. </returns>
+        private string GetBaseAddress(string fullUrl)
+        {
+            if (string.IsNullOrEmpty(fullUrl))
+            {
+                return _baseAddress;
+            }
+            if (fullUrl.StartsWith(_baseAddress))
+            {
+                return fullUrl[_baseAddress.Length..];
+            }
+            return fullUrl;
+        }
+
+        /// <summary>
         /// Disposes the <see cref="WebDavCloudClient"/> instance.
         /// </summary>
         public void Dispose()

--- a/Sources/EasyExtensions.WebDav/WebDavCloudClient.cs
+++ b/Sources/EasyExtensions.WebDav/WebDavCloudClient.cs
@@ -201,7 +201,7 @@ namespace EasyExtensions.WebDav
         /// Substracts the base address from the full URL.
         /// </summary>
         /// <returns> The path without the base address if it starts with the base address. If not, the full URL is returned. </returns>
-        private string SubstractBaseAddress(string fullUrl)
+        private string GetRelativeUrl(string fullUrl)
         {
             if (string.IsNullOrEmpty(fullUrl))
             {


### PR DESCRIPTION
Useful when dealing with full URIs. Such as

```
// Check if the image is already in the database
var imageRecord = await _appDbContext.ImageFiles
    .FirstOrDefaultAsync(x => x.FilePath == resource.Uri); // Here we need to substract the base path
```